### PR TITLE
Fix Errbot Flows with RocketChat Backend

### DIFF
--- a/src/rocketchat/backends/rocketchat.py
+++ b/src/rocketchat/backends/rocketchat.py
@@ -265,6 +265,8 @@ class RocketChatUser(Person):
         # Return user name
         return self._person
 
+    def __eq__(self, __o: object) -> bool:
+        return self._person == __o._person
 
 class RocketChat(ErrBot):
     """


### PR DESCRIPTION
The RocketChatUser class is missing a proper comparison method.
When Errbot compares two RocketChatUser objects using '==' operator, python checks strict object equality instead of semantic equality.

closes #14 